### PR TITLE
Home page links full screen on IOS

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -20,6 +20,7 @@
 <html ng-app="subtrack90">
 <head>
   <meta charset="utf-8"/>
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="format-detection" content="telephone=no"/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0,
     width=device-width"/>


### PR DESCRIPTION
This meta tag instructs IOS to show this web page full screen, if it's started from a home page link.

It works brilliantly.  Goodness knows if it will break something in Cordova though!
